### PR TITLE
Add commands to sync alerts from ZeroFox to XSOAR

### DIFF
--- a/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.yml
+++ b/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.yml
@@ -1049,6 +1049,9 @@ script:
     description: Looks for registered exploits in ZeroFox's CTI feeds
   dockerimage: demisto/python3:3.10.11.61265
   isfetch: true
+  ismappable: true
+  isremotesyncin: true
+  isremotesyncout: false
   longRunning: false
   longRunningPort: false
   runonce: false


### PR DESCRIPTION
It adds the commands:
- get-modified-remote-data: to get modified alerts from ZeroFox API periodically
- get-remote-data: to get the alert from the previous command and its modifications to update the incident in xsoar

Also, it adds the config required to sync in the YML file and adds to the alert some fields to run the mirroring.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
