### PR TITLE
Add a config param to fetch only escalated alerts

### DIFF
--- a/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.yml
+++ b/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.yml
@@ -14,8 +14,9 @@ configuration:
   type: 9
 - display: Escalated Alerts Only
   name: only_escalated
-  required: true
   type: 8
+  required: false
+  defaultvalue: 'false'
 - display: Trust any certificate (not secure)
   name: insecure
   type: 8
@@ -24,16 +25,16 @@ configuration:
   name: proxy
   type: 8
   required: false
-- defaultvalue: 3 days
+- defaultvalue: '3 days'
   display: First fetch timestamp (<number> <time unit>, e.g., 12 hours, 7 days)
   name: fetch_time
-  type: 0
   required: false
-- defaultvalue: '100'
-  display: Fetch Limit
-  name: fetch_limit
-  required: true
   type: 0
+- display: Fetch Limit
+  name: fetch_limit
+  type: 0
+  required: true
+  defaultvalue: '100'
 - display: Fetch incidents
   name: isFetch
   type: 8
@@ -887,7 +888,7 @@ script:
     - contextPath: ZeroFox.Exploits.URLs
       description: URLs associated to the threat separated by commas.
       type: string
-  dockerimage: demisto/python3:3.10.13.72123
+  dockerimage: demisto/python3:3.10.13.74666
   isfetch: true
   longRunning: false
   longRunningPort: false

--- a/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.yml
+++ b/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox.yml
@@ -12,6 +12,10 @@ configuration:
   name: credentials
   required: true
   type: 9
+- display: Escalated Alerts Only
+  name: only_escalated
+  required: true
+  type: 8
 - display: Trust any certificate (not secure)
   name: insecure
   type: 8

--- a/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox_test.py
+++ b/Packs/ZeroFox/Integrations/ZeroFox/ZeroFox_test.py
@@ -45,6 +45,7 @@ def build_zf_client() -> ZFClient:
         username='',
         password='',
         fetch_limit=FETCH_LIMIT,
+        only_escalated=False,
     )
 
 

--- a/Packs/ZeroFox/ReleaseNotes/1_2_0.md
+++ b/Packs/ZeroFox/ReleaseNotes/1_2_0.md
@@ -1,0 +1,8 @@
+
+#### Integrations
+
+##### ZeroFox
+
+- Added the parameter `only_escalated` so that users can choose to only fetch escalated alerts.
+- Fixed an issue related with requests that have body.
+- Updated the Docker image to: *demisto/python3:3.10.13.74666*.

--- a/Packs/ZeroFox/pack_metadata.json
+++ b/Packs/ZeroFox/pack_metadata.json
@@ -2,7 +2,7 @@
     "name": "ZeroFox",
     "description": "Cloud-based SaaS to detect risks found on social media and digital channels.",
     "support": "partner",
-    "currentVersion": "1.1.1",
+    "currentVersion": "1.2.0",
     "author": "ZeroFox",
     "url": "https://www.zerofox.com/contact-us/",
     "email": "integration-support@zerofox.com",


### PR DESCRIPTION
- It adds a config param to fetch only escalated alerts

- It fixes the requests that have body, so it is automatically parsed

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->
## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [ ] In Progress
- [x] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Must have
- [ ] Tests
- [ ] Documentation 
